### PR TITLE
Partially encoded streams

### DIFF
--- a/models.go
+++ b/models.go
@@ -1,8 +1,11 @@
 package decouplet
 
 const errorMatchNotFound string = "match not found"
-const partialStart string = "<.;["
-const partialEnd string = "];tc.>"
+const partialStart string = ";[&"
+const partialEnd string = "&];"
+
+var partialStartBytes = []byte(partialStart)
+var partialEndBytes = []byte(partialEnd)
 
 type TranscoderType string
 

--- a/models.go
+++ b/models.go
@@ -1,6 +1,8 @@
 package decouplet
 
-const errorMatchNotFound = "match not found"
+const errorMatchNotFound string = "match not found"
+const partialStart string = "<.;["
+const partialEnd string = "];tc.>"
 
 type TranscoderType string
 

--- a/transcoder.go
+++ b/transcoder.go
@@ -227,8 +227,7 @@ func TransdecodeStream(
 				writer.CloseWithError(err)
 			}
 			if chars.CheckIn(b) {
-				groupsFound++
-				if groupsFound == groups+1 {
+				if groupsFound == groups {
 					err = writeDecodeBuffer(
 						decodeFunc, buffer, chars, groups, key, writer)
 					if err != nil {
@@ -236,8 +235,9 @@ func TransdecodeStream(
 						return
 					}
 					buffer = make([]byte, 0)
-					groupsFound = 1
+					groupsFound = 0
 				}
+				groupsFound++
 			}
 			buffer = append(buffer, b)
 		}

--- a/transcoder.go
+++ b/transcoder.go
@@ -227,8 +227,7 @@ func TransdecodeStream(
 				writer.CloseWithError(err)
 			}
 			if chars.CheckIn(b) {
-				groupsFound++
-				if groupsFound == groups+1 {
+				if groupsFound == groups {
 					err = writeDecodeBuffer(
 						decodeFunc, buffer, chars, groups, key, writer)
 					if err != nil {
@@ -236,8 +235,9 @@ func TransdecodeStream(
 						return
 					}
 					buffer = make([]byte, 0)
-					groupsFound = 1
+					groupsFound = 0
 				}
+				groupsFound++
 			}
 			buffer = append(buffer, b)
 		}
@@ -271,6 +271,85 @@ func readTranscodedStream(
 	}
 	return b[0], nil
 }
+
+//func TransdecodeStreamPartial(
+//	input io.Reader,
+//	key Key,
+//	groups int,
+//	take int,
+//	skip int,
+//	decodeFunc func(Key, DecodeGroup) (byte, error),
+//) (output io.Reader, err error) {
+//	chars := key.GetDictionaryChars()
+//	groupsFound := 0
+//	buffer := make([]byte, 0)
+//	reader, writer := io.Pipe()
+//	go func() {
+//		taken := 0
+//		taking := true
+//		for {
+//			if !taking {
+//				b := make([]byte, skip)
+//				_, err := input.Read(b)
+//				if err != nil {
+//					writer.CloseWithError(err)
+//					return
+//				}
+//				_, err = writer.Write(b)
+//				if err != nil {
+//					writer.CloseWithError(err)
+//				}
+//				println("Bytes to send skipped", string(b))
+//				println("Going from skipping to taking")
+//				taking = true
+//			} else {
+//				println("I to go through:", take*groups)
+//				for i := 0; i < take*groups; i++ {
+//					if taken == take {
+//						println("NOT TAKING ANYMORE", taken, "/", take)
+//						taken = 0
+//						taking = false
+//					}
+//					b := make([]byte, 1)
+//					_, err := input.Read(b)
+//					if err != nil {
+//						if err == io.EOF {
+//							err = writeDecodeBuffer(
+//								decodeFunc, buffer, chars, groups, key, writer)
+//							if err != nil {
+//								writer.CloseWithError(err)
+//								return
+//							}
+//							writer.Close()
+//							return
+//						} else {
+//							writer.CloseWithError(err)
+//							return
+//						}
+//					}
+//					if chars.CheckIn(b[0]) {
+//						groupsFound++
+//						if groupsFound == groups+1 {
+//							err = writeDecodeBuffer(
+//								decodeFunc, buffer, chars, groups, key, writer)
+//							if err != nil {
+//								writer.CloseWithError(err)
+//								return
+//							}
+//							buffer = make([]byte, 0)
+//							taken++
+//							println("TAKING:", taken)
+//							groupsFound = 1
+//						}
+//					}
+//					buffer = append(buffer, b[0])
+//				}
+//			}
+//		}
+//	}()
+//
+//	return reader, nil
+//}
 
 func writeDecodeBuffer(
 	decodeFunc func(Key, DecodeGroup) (byte, error),

--- a/transcoder.go
+++ b/transcoder.go
@@ -111,7 +111,7 @@ func TranscodeStreamPartial(
 					writer.CloseWithError(err)
 				}
 				taken++
-				if taken > take {
+				if taken >= take {
 					taken = 0
 					taking = false
 				}
@@ -120,8 +120,8 @@ func TranscodeStreamPartial(
 				if err != nil {
 					writer.CloseWithError(err)
 				}
-				skip++
-				if skipped > skip {
+				skipped++
+				if skipped >= skip {
 					skipped = 0
 					taking = true
 				}

--- a/transcoder.go
+++ b/transcoder.go
@@ -227,7 +227,8 @@ func TransdecodeStream(
 				writer.CloseWithError(err)
 			}
 			if chars.CheckIn(b) {
-				if groupsFound == groups {
+				groupsFound++
+				if groupsFound == groups+1 {
 					err = writeDecodeBuffer(
 						decodeFunc, buffer, chars, groups, key, writer)
 					if err != nil {
@@ -235,9 +236,8 @@ func TransdecodeStream(
 						return
 					}
 					buffer = make([]byte, 0)
-					groupsFound = 0
+					groupsFound = 1
 				}
-				groupsFound++
 			}
 			buffer = append(buffer, b)
 		}
@@ -271,85 +271,6 @@ func readTranscodedStream(
 	}
 	return b[0], nil
 }
-
-//func TransdecodeStreamPartial(
-//	input io.Reader,
-//	key Key,
-//	groups int,
-//	take int,
-//	skip int,
-//	decodeFunc func(Key, DecodeGroup) (byte, error),
-//) (output io.Reader, err error) {
-//	chars := key.GetDictionaryChars()
-//	groupsFound := 0
-//	buffer := make([]byte, 0)
-//	reader, writer := io.Pipe()
-//	go func() {
-//		taken := 0
-//		taking := true
-//		for {
-//			if !taking {
-//				b := make([]byte, skip)
-//				_, err := input.Read(b)
-//				if err != nil {
-//					writer.CloseWithError(err)
-//					return
-//				}
-//				_, err = writer.Write(b)
-//				if err != nil {
-//					writer.CloseWithError(err)
-//				}
-//				println("Bytes to send skipped", string(b))
-//				println("Going from skipping to taking")
-//				taking = true
-//			} else {
-//				println("I to go through:", take*groups)
-//				for i := 0; i < take*groups; i++ {
-//					if taken == take {
-//						println("NOT TAKING ANYMORE", taken, "/", take)
-//						taken = 0
-//						taking = false
-//					}
-//					b := make([]byte, 1)
-//					_, err := input.Read(b)
-//					if err != nil {
-//						if err == io.EOF {
-//							err = writeDecodeBuffer(
-//								decodeFunc, buffer, chars, groups, key, writer)
-//							if err != nil {
-//								writer.CloseWithError(err)
-//								return
-//							}
-//							writer.Close()
-//							return
-//						} else {
-//							writer.CloseWithError(err)
-//							return
-//						}
-//					}
-//					if chars.CheckIn(b[0]) {
-//						groupsFound++
-//						if groupsFound == groups+1 {
-//							err = writeDecodeBuffer(
-//								decodeFunc, buffer, chars, groups, key, writer)
-//							if err != nil {
-//								writer.CloseWithError(err)
-//								return
-//							}
-//							buffer = make([]byte, 0)
-//							taken++
-//							println("TAKING:", taken)
-//							groupsFound = 1
-//						}
-//					}
-//					buffer = append(buffer, b[0])
-//				}
-//			}
-//		}
-//	}()
-//
-//	return reader, nil
-//}
 
 func writeDecodeBuffer(
 	decodeFunc func(Key, DecodeGroup) (byte, error),

--- a/transcoder.go
+++ b/transcoder.go
@@ -91,6 +91,10 @@ func TranscodeStreamPartial(
 	go func() {
 		defer writer.Close()
 		for {
+			_, err = writer.Write([]byte(partialStart))
+			if err != nil {
+				return
+			}
 			takeBytes := make([]byte, take)
 			skip := make([]byte, skip)
 			_, err := input.Read(takeBytes)
@@ -102,11 +106,16 @@ func TranscodeStreamPartial(
 			if err != nil {
 				return
 			}
-			b, err := ioutil.ReadAll(tcReader)
+			tcBytes, err := ioutil.ReadAll(tcReader)
 			if err != nil {
 				return
 			}
-			_, err = writer.Write(b)
+
+			_, err = writer.Write(tcBytes)
+			if err != nil {
+				return
+			}
+			_, err = writer.Write([]byte(partialEnd))
 			if err != nil {
 				return
 			}

--- a/transcoder_byte.go
+++ b/transcoder_byte.go
@@ -25,7 +25,7 @@ func (keyBytes) GetKeyType() TranscoderType {
 }
 
 func (keyBytes) GetDictionaryChars() DictionaryChars {
-	return DictionaryChars("abcdefghij")
+	return DictionaryChars("abcdefghijk")
 }
 
 func (keyBytes) GetDictionary() Dictionary {
@@ -33,42 +33,46 @@ func (keyBytes) GetDictionary() Dictionary {
 		decoders: []Decoder{
 			{
 				character: 'a',
-				amount:    1,
+				amount:    0,
 			},
 			{
 				character: 'b',
-				amount:    2,
+				amount:    1,
 			},
 			{
 				character: 'c',
-				amount:    4,
+				amount:    2,
 			},
 			{
 				character: 'd',
-				amount:    6,
+				amount:    4,
 			},
 			{
 				character: 'e',
-				amount:    8,
+				amount:    6,
 			},
 			{
 				character: 'f',
-				amount:    10,
+				amount:    8,
 			},
 			{
 				character: 'g',
-				amount:    16,
+				amount:    10,
 			},
 			{
 				character: 'h',
-				amount:    32,
+				amount:    16,
 			},
 			{
 				character: 'i',
-				amount:    64,
+				amount:    32,
 			},
 			{
 				character: 'j',
+				amount:    64,
+			},
+			{
+				character: 'k',
 				amount:    128,
 			},
 		},
@@ -90,6 +94,11 @@ func TranscodeBytesStream(input io.Reader, key []byte) (io.Reader, error) {
 		input, keyBytes(key), findBytePattern)
 }
 
+func TranscodeBytesStreamPartial(input io.Reader, key []byte, take int, skip int) (io.Reader, error) {
+	return TranscodeStreamPartial(
+		input, keyBytes(key), take, skip, findBytePattern)
+}
+
 func TransdecodeBytes(input []byte, key []byte) ([]byte, error) {
 	return Transdecode(
 		input, keyBytes(key), 2, getByteDefs)
@@ -97,6 +106,11 @@ func TransdecodeBytes(input []byte, key []byte) ([]byte, error) {
 
 func TransdecodeBytesStream(input io.Reader, key []byte) (io.Reader, error) {
 	return TransdecodeStream(
+		input, keyBytes(key), 2, getByteDefs)
+}
+
+func TransdecodeBytesStreamPartial(input io.Reader, key []byte) (io.Reader, error) {
+	return TransdecodeStreamPartial(
 		input, keyBytes(key), 2, getByteDefs)
 }
 

--- a/transcoder_byte_test.go
+++ b/transcoder_byte_test.go
@@ -104,3 +104,25 @@ func TestTranscodeBytesConcurrent(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestTranscodeBytesConcurrentPartial(t *testing.T) {
+	key := []byte("tEst Key3#$!@&*()[]:;")
+	msg := []byte("Test this message and see it stream and be partially encoded! here")
+	take := 1
+	skip := 3
+	input := bytes.NewReader(msg)
+	reader, err := TranscodeBytesStreamPartial(input, key, take, skip)
+	if err != nil {
+		t.Error(err)
+	}
+	newReader, err := TransdecodeBytesStreamPartial(reader, key)
+	if err != nil {
+		t.Error(err)
+	}
+	b, err := ioutil.ReadAll(newReader)
+	t.Log(string(b))
+	if !bytes.Equal(msg, b) {
+		t.Log("bytes are not equal")
+		t.Fail()
+	}
+}

--- a/transcoder_image.go
+++ b/transcoder_image.go
@@ -103,6 +103,11 @@ func TranscodeImageStream(input io.Reader, key image.Image) (io.Reader, error) {
 		input, imageKey{key}, findPixelPattern)
 }
 
+func TranscodeImageStreamPartial(input io.Reader, key image.Image, take int, skip int) (io.Reader, error) {
+	return TranscodeStreamPartial(
+		input, imageKey{key}, take, skip, findPixelPattern)
+}
+
 func TranscodeImageConcurrent(input []byte, key image.Image) ([]byte, error) {
 	return TranscodeConcurrent(
 		input, imageKey{key}, findPixelPattern)
@@ -116,6 +121,11 @@ func TransdecodeImage(input []byte, key image.Image) ([]byte, error) {
 
 func TransdecodeImageStream(input io.Reader, key image.Image) (io.Reader, error) {
 	return TransdecodeStream(
+		input, imageKey{key}, 2, getImgDefs)
+}
+
+func TransdecodeImageStreamPartial(input io.Reader, key image.Image) (io.Reader, error) {
+	return TransdecodeStreamPartial(
 		input, imageKey{key}, 2, getImgDefs)
 }
 

--- a/transcoder_image_test.go
+++ b/transcoder_image_test.go
@@ -119,3 +119,28 @@ func TestTranscodeImageConcurrent(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestTranscodeImageConcurrentPartial(t *testing.T) {
+	image, err := LoadImage("images/test.jpg")
+	if err != nil {
+		t.Error(err)
+	}
+	take := 1
+	skip := 3
+	msg := []byte("Test this message and see it stream, using partial encoding.")
+	input := bytes.NewReader(msg)
+	reader, err := TranscodeImageStreamPartial(input, image, take, skip)
+	if err != nil {
+		t.Error(err)
+	}
+	newReader, err := TransdecodeImageStreamPartial(reader, image)
+	if err != nil {
+		t.Error(err)
+	}
+	b, err := ioutil.ReadAll(newReader)
+	t.Log(string(b))
+	if !bytes.Equal(msg, b) {
+		t.Log("bytes are not equal")
+		t.Fail()
+	}
+}

--- a/versions.json
+++ b/versions.json
@@ -5,6 +5,6 @@
   },
   {
     "name":     "bytetc",
-    "version":  "0.1"
+    "version":  "0.2"
   }
 ]


### PR DESCRIPTION
This adds in partially encoded streams to decouplet, to cut down on potential size in stream. 

Sometimes you may want a smaller size but also want the potential obfuscation, and this will allow that.