### PR TITLE
Partial decode stream fix

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -92,9 +92,9 @@ func scanDecodeStream(
 		splitBytes := bytes.SplitAfter(scanner.Bytes(), partialStartBytes)
 		var skipped []byte
 		if len(splitBytes[0]) < len(partialStartBytes) {
-			skipped = splitBytes[0][0:len(splitBytes[0])]
+			skipped = splitBytes[0][:len(splitBytes[0])]
 		} else {
-			skipped = splitBytes[0][0 : len(splitBytes[0])-len(partialStartBytes)]
+			skipped = bytes.TrimRight(splitBytes[0], partialStart)
 		}
 		_, err := writer.Write(skipped)
 		if err != nil {

--- a/encoder_byte_test.go
+++ b/encoder_byte_test.go
@@ -137,7 +137,8 @@ func TestAnalyzeBytesKey(t *testing.T) {
 		t.Fail()
 	}
 	greatKey := []byte(
-		"GREAFgolanVMb elefwoejgitoiqwaz12353445789870-0=)(_#@$^#$&$%&$*$&$0238959_=2340+=12!@#$%^&*(()")
+		"GREAFgolanVMb elefwoejgitoiqwaz12353445789870-0=)" +
+			"(_#@$^#$&$%&$*$&$0238959_=2340+=12!@#$%^&*(()")
 	scale = AnalyzeBytesKey(greatKey)
 	if scale < 20 {
 		t.Log("great keys should be 20 or over(not really a hard number)")


### PR DESCRIPTION
Fixed a logical issue that didn't come out during testing. This is a rare case where the encoder did not put a new start of the bytes at the end, and so the end got cut off. The new fix will handle either event correctly.