### PR TITLE
Encoding Fixes - Primarily ECB

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -12,6 +12,10 @@ func decode(
 	groups int,
 	decodeFunc func(encodingKey, decodeGroup) (byte, error),
 ) (output []byte, err error) {
+	if valid, err := key.CheckValid(); !valid {
+		return nil, err
+	}
+
 	err = key.GetVersion().CheckEncoder(&input)
 	if err != nil {
 		return nil, err
@@ -31,6 +35,10 @@ func decodeStream(
 	groups int,
 	decodeFunc func(encodingKey, decodeGroup) (byte, error),
 ) (output *io.PipeReader, err error) {
+	if valid, err := key.CheckValid(); !valid {
+		return nil, err
+	}
+
 	reader, writer := io.Pipe()
 
 	go func() {
@@ -81,6 +89,10 @@ func decodePartialStream(
 	groups int,
 	decodeFunc func(encodingKey, decodeGroup) (byte, error),
 ) (output *io.PipeReader, err error) {
+	if valid, err := key.CheckValid(); !valid {
+		return nil, err
+	}
+
 	reader, writer := io.Pipe()
 
 	go func() {

--- a/encoder_byte.go
+++ b/encoder_byte.go
@@ -226,19 +226,19 @@ func getBytePattern(char byte, key bytesKey) ([]byte, error) {
 		for x := startFinding; x >= 0; x-- {
 			pattern, err = findBytePartner(current, x, char, key, dictionary)
 			if err == nil {
-				break
+				return pattern, nil
 			}
 		}
 	} else {
 		for x := startFinding; x < bounds; x++ {
 			pattern, err = findBytePartner(current, x, char, key, dictionary)
 			if err == nil {
-				break
+				return pattern, nil
 			}
 		}
 	}
 
-	return pattern, err
+	return nil, err
 }
 
 func findBytePartner(

--- a/encoder_byte.go
+++ b/encoder_byte.go
@@ -21,12 +21,22 @@ type byteChecked struct {
 type bytesKey []byte
 
 const matchFindRetriesByte = 16
+const minByteKeySize = 64
+
+var errorByteKeyTooShort = errors.New("key is smaller than minimum length of 64 bytes")
 
 func (bytesKey) GetVersion() EncoderInfo {
 	return EncoderInfo{
 		Name:    "byteec",
 		Version: "0.2",
 	}
+}
+
+func (k bytesKey) CheckValid() (bool, error) {
+	if len(k) < minByteKeySize {
+		return false, errorByteKeyTooShort
+	}
+	return true, nil
 }
 
 func (bytesKey) GetDictionaryChars() dictionaryChars {
@@ -91,14 +101,14 @@ func EncodeBytes(input []byte, key []byte) ([]byte, error) {
 }
 
 // EncodeBytesStream encodes a byte stream against a key which is a slice of bytes.
-func EncodeBytesStream(input io.Reader, key []byte) *io.PipeReader {
+func EncodeBytesStream(input io.Reader, key []byte) (*io.PipeReader, error) {
 	return encodeStream(
 		input, bytesKey(key), findBytePattern)
 }
 
 // EncodeBytesStreamPartial encodes a byte stream partially against a key which is a slice of bytes.
 // Arguments take and skip are used to determine how many bytes to take, and skip along a stream.
-func EncodeBytesStreamPartial(input io.Reader, key []byte, take int, skip int) *io.PipeReader {
+func EncodeBytesStreamPartial(input io.Reader, key []byte, take int, skip int) (*io.PipeReader, error) {
 	return encodePartialStream(
 		input, bytesKey(key), take, skip, findBytePattern)
 }

--- a/encoder_byte_test.go
+++ b/encoder_byte_test.go
@@ -30,13 +30,14 @@ func TestByteMessage(t *testing.T) {
 	originalMessage :=
 		"!!**_-+Test THIS bigger message with More Symbols" +
 			"@$_()#$%^#@!~#2364###$%! *(#$%)^@#%$@"
+	key := []byte("Test encodingKey!@# $Aaaaaallgglglmefmogaloehkogpeloskoge ekgogjwogkl 2346923052306235023060923503289362305028602395026023950260235028602597235923")
 	newMessage, err := EncodeBytes(
-		[]byte(originalMessage), []byte("Test encodingKey!@# $"))
+		[]byte(originalMessage), key)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log(string(newMessage))
-	message, err := DecodeBytes(newMessage, []byte("Test encodingKey!@# $"))
+	message, err := DecodeBytes(newMessage, key)
 	if err != nil {
 		t.Error(err)
 	}
@@ -266,45 +267,6 @@ func TestImageBytePPM(t *testing.T) {
 		fmt.Println(err)
 	}
 	decoded, err := DecodeBytesStream(reader, key2)
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
-	data, err := ioutil.ReadAll(decoded)
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
-	err = ioutil.WriteFile("images/body.ecb.bin", data, 0644)
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
-
-}
-
-func TestImageImagePPM(t *testing.T) {
-	file, err := os.Open("images/body.bin")
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
-	key, err := LoadImage("images/gopher.png")
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
-	reader, err := EncodeImageStream(file, key)
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
-	key2, err := LoadImage("images/test.png")
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
-	decoded, err := DecodeImageStream(reader, key2)
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/encoder_byte_test.go
+++ b/encoder_byte_test.go
@@ -2,6 +2,7 @@ package decouplet
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,7 +10,7 @@ import (
 )
 
 func TestEncodeBytes(t *testing.T) {
-	newMessage, err := EncodeBytes([]byte("Test"), []byte("tEst Key3#$T234"))
+	newMessage, err := EncodeBytes([]byte("Test"), []byte("tEst Key3#$T234Alklgn"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -18,7 +19,7 @@ func TestEncodeBytes(t *testing.T) {
 
 func TestDecoderBytes(t *testing.T) {
 	message, err := DecodeBytes(
-		[]byte("[dcplt-byteec-0.2]a9c0e8j4j8d4j8c9"), []byte("tEst Key3#$"))
+		[]byte("[dcplt-byteec-0.2]e12i16d17k11k17g11k12e4"), []byte("tEst Key3#$"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -90,10 +91,13 @@ func TestEncodeBytesConcurrent(t *testing.T) {
 	key := []byte("tEst Key3#$!@&*()[]:;")
 	msg := []byte("Test this message and see it stream")
 	input := bytes.NewReader(msg)
-	reader := EncodeBytesStream(input, key)
+	reader, err := EncodeBytesStream(input, key)
+	if err != nil {
+		t.Fatal(err)
+	}
 	newReader, err := DecodeBytesStream(reader, key)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	b, err := ioutil.ReadAll(newReader)
 	t.Log(string(b))
@@ -109,7 +113,11 @@ func TestEncodeBytesConcurrentPartial(t *testing.T) {
 	take := 1
 	skip := 3
 	input := bytes.NewReader(msg)
-	reader := EncodeBytesStreamPartial(input, key, take, skip)
+	reader, err := EncodeBytesStreamPartial(input, key, take, skip)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
 	newReader, err := DecodeBytesStreamPartial(reader, key)
 	if err != nil {
 		t.Error(err)
@@ -162,7 +170,10 @@ func ExampleEncodeBytesStream() {
 	key := []byte("tEst Key3#$!@&*()[]:;")
 	msg := []byte("Test this message and see it stream")
 	input := bytes.NewReader(msg)
-	reader := EncodeBytesStream(input, key)
+	reader, err := EncodeBytesStream(input, key)
+	if err != nil {
+		fmt.Println(err)
+	}
 	message, err := ioutil.ReadAll(reader)
 	if err != nil {
 		fmt.Println(err)
@@ -176,7 +187,10 @@ func ExampleEncodeBytesStreamPartial() {
 	take := 4
 	skip := 10
 	input := bytes.NewReader(msg)
-	reader := EncodeBytesStreamPartial(input, key, take, skip)
+	reader, err := EncodeBytesStreamPartial(input, key, take, skip)
+	if err != nil {
+		fmt.Println(err)
+	}
 	message, err := ioutil.ReadAll(reader)
 	if err != nil {
 		fmt.Println(err)
@@ -227,4 +241,83 @@ func ExampleDecodeBytesStreamPartial() {
 		fmt.Println(err)
 	}
 	fmt.Println("output:", string(message))
+}
+
+func TestImageBytePPM(t *testing.T) {
+	file, err := os.Open("images/body.bin")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	key := make([]byte, 256)
+	_, err = rand.Read(key)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	key2 := make([]byte, 256)
+	_, err = rand.Read(key2)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	reader, err := EncodeBytesStream(file, key)
+	if err != nil {
+		fmt.Println(err)
+	}
+	decoded, err := DecodeBytesStream(reader, key2)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	data, err := ioutil.ReadAll(decoded)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	err = ioutil.WriteFile("images/body.ecb.bin", data, 0644)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+}
+
+func TestImageImagePPM(t *testing.T) {
+	file, err := os.Open("images/body.bin")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	key, err := LoadImage("images/gopher.png")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	reader, err := EncodeImageStream(file, key)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	key2, err := LoadImage("images/test.png")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	decoded, err := DecodeImageStream(reader, key2)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	data, err := ioutil.ReadAll(decoded)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	err = ioutil.WriteFile("images/body.ecb.bin", data, 0644)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
 }

--- a/encoder_image.go
+++ b/encoder_image.go
@@ -224,52 +224,31 @@ func getPixelPattern(char byte, key imageKey) ([]byte, error) {
 	currentLocation := location{x: currentX, y: currentY}
 	currentColor := key.At(currentX, currentY)
 
+	changeX := 0
+	changeY := 0
+
 	if startX > bounds.Max.X/2 {
-		for x := startX; x >= 0; x-- {
-			if startY > bounds.Max.Y/2 {
-				for y := startY; y >= 0; y-- {
-					checkedLocation := location{x, y}
-					checkedColor := key.At(x, y)
-					pattern, err = findPixelPartner(
-						currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
-					if err == nil {
-						return pattern, nil
-					}
-				}
-			} else {
-				for y := startY; y < bounds.Max.Y; y++ {
-					checkedLocation := location{x, y}
-					checkedColor := key.At(x, y)
-					pattern, err = findPixelPartner(
-						currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
-					if err == nil {
-						return pattern, nil
-					}
-				}
-			}
-		}
+		changeX = -1
 	} else {
-		for x := startX; x < bounds.Max.X; x++ {
-			if startY > bounds.Max.Y/2 {
-				for y := startY; y >= 0; y-- {
-					checkedLocation := location{x, y}
-					checkedColor := key.At(x, y)
-					pattern, err = findPixelPartner(
-						currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
-					if err == nil {
-						return pattern, nil
-					}
-				}
-			} else {
-				for y := startY; y < bounds.Max.Y; y++ {
-					checkedLocation := location{x, y}
-					checkedColor := key.At(x, y)
-					pattern, err = findPixelPartner(
-						currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
-					if err == nil {
-						return pattern, nil
-					}
-				}
+		changeX = 1
+	}
+	if startY > bounds.Max.Y/2 {
+		changeY = -1
+	} else {
+		changeY = 1
+	}
+
+	for x := startX; (changeX == -1 && x >= 0) ||
+		(changeX == 1 && x < bounds.Max.X); x += changeX {
+		for y := startY; (changeY == -1 && y >= 0) ||
+			(changeY == 1 && y < bounds.Max.Y); y += changeY {
+
+			checkedLocation := location{x, y}
+			checkedColor := key.At(x, y)
+			pattern, err = findPixelPartner(
+				currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
+			if err == nil {
+				return pattern, nil
 			}
 		}
 	}

--- a/encoder_image.go
+++ b/encoder_image.go
@@ -20,12 +20,22 @@ type imageKey struct {
 }
 
 const matchFindRetriesImage = 4
+const imageKeySize = 300
+
+var errorImageKeyTooSmall = errors.New("key needs to be larger than 300x300")
 
 func (imageKey) GetVersion() EncoderInfo {
 	return EncoderInfo{
 		Name:    "imgec",
 		Version: "0.2",
 	}
+}
+
+func (k imageKey) CheckValid() (bool, error) {
+	if k.Image.Bounds().Max.X < imageKeySize || k.Image.Bounds().Max.Y < imageKeySize {
+		return false, errorImageKeyTooSmall
+	}
+	return true, nil
 }
 
 func (imageKey) GetDictionaryChars() dictionaryChars {
@@ -105,14 +115,14 @@ func EncodeImage(input []byte, key image.Image) ([]byte, error) {
 }
 
 // EncodeImageStream encodes a stream of bytes against an image key.
-func EncodeImageStream(input io.Reader, key image.Image) *io.PipeReader {
+func EncodeImageStream(input io.Reader, key image.Image) (*io.PipeReader, error) {
 	return encodeStream(
 		input, imageKey{key}, findPixelPattern)
 }
 
 // EncodeImageStreamPartial encodes a byte stream partially against an image key.
 // Arguments take and skip are used to determine how many bytes to take, and skip along a stream.
-func EncodeImageStreamPartial(input io.Reader, key image.Image, take int, skip int) *io.PipeReader {
+func EncodeImageStreamPartial(input io.Reader, key image.Image, take int, skip int) (*io.PipeReader, error) {
 	return encodePartialStream(
 		input, imageKey{key}, take, skip, findPixelPattern)
 }

--- a/encoder_image.go
+++ b/encoder_image.go
@@ -193,58 +193,111 @@ func getImgDefs(key encodingKey, group decodeGroup) (byte, error) {
 }
 
 func findPixelPattern(char byte, key encodingKey) ([]byte, error) {
-	img, ok := key.(imageKey)
+	imageKey, ok := key.(imageKey)
 	if !ok {
-		return nil, errors.New("failed to cast key")
+		return nil, errorKeyCastFailed
 	}
-	bounds := img.Bounds()
+	var pattern []byte
+	var err error
+
+	for i := 0; i < matchFindRetriesImage; i++ {
+		pattern, err = getPixelPattern(char, imageKey)
+		if err == nil {
+			return pattern, nil
+		}
+	}
+
+	return nil, err
+}
+
+func getPixelPattern(char byte, key imageKey) ([]byte, error) {
+	bounds := key.Bounds()
+	currentX := rand.Intn(bounds.Max.X)
+	currentY := rand.Intn(bounds.Max.Y)
 	startX := rand.Intn(bounds.Max.X)
 	startY := rand.Intn(bounds.Max.Y)
-	firstColor := img.At(startX, startY)
+	dictionary := key.GetDictionary()
 
-	pattern, err := findPixelPartner(
-		location{x: startX, y: startY}, char, firstColor, img, key.GetDictionary())
-	if err != nil && err == errorMatchNotFound {
-		for i := 0; i < matchFindRetriesImage; i++ {
-			startX = rand.Intn(bounds.Max.X)
-			startY = rand.Intn(bounds.Max.Y)
-			firstColor = img.At(startX, startY)
+	pattern := make([]byte, 0)
+	var err error
 
-			pattern, err = findPixelPartner(
-				location{x: startX, y: startY}, char, firstColor, img, key.GetDictionary())
-			if err == nil {
-				break
+	currentLocation := location{x: currentX, y: currentY}
+	currentColor := key.At(currentX, currentY)
+
+	if startX > bounds.Max.X/2 {
+		for x := startX; x >= 0; x-- {
+			if startY > bounds.Max.Y/2 {
+				for y := startY; y >= 0; y-- {
+					checkedLocation := location{x, y}
+					checkedColor := key.At(x, y)
+					pattern, err = findPixelPartner(
+						currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
+					if err == nil {
+						return pattern, nil
+					}
+				}
+			} else {
+				for y := startY; y < bounds.Max.Y; y++ {
+					checkedLocation := location{x, y}
+					checkedColor := key.At(x, y)
+					pattern, err = findPixelPartner(
+						currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
+					if err == nil {
+						return pattern, nil
+					}
+				}
+			}
+		}
+	} else {
+		for x := startX; x < bounds.Max.X; x++ {
+			if startY > bounds.Max.Y/2 {
+				for y := startY; y >= 0; y-- {
+					checkedLocation := location{x, y}
+					checkedColor := key.At(x, y)
+					pattern, err = findPixelPartner(
+						currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
+					if err == nil {
+						return pattern, nil
+					}
+				}
+			} else {
+				for y := startY; y < bounds.Max.Y; y++ {
+					checkedLocation := location{x, y}
+					checkedColor := key.At(x, y)
+					pattern, err = findPixelPartner(
+						currentLocation, checkedLocation, char, currentColor, checkedColor, key, dictionary)
+					if err == nil {
+						return pattern, nil
+					}
+				}
 			}
 		}
 	}
-	if err != nil {
-		return nil, err
-	}
-	return pattern, nil
+
+	return nil, err
 }
 
 func findPixelPartner(
-	location location,
+	currentLocation location,
+	checkedLocation location,
 	difference byte,
 	currentColor color.Color,
-	img image.Image,
+	checkedColor color.Color,
+	key image.Image,
 	dict dictionary) ([]byte, error) {
-	bounds := img.Bounds()
-	for x := 0; x < bounds.Max.X; x++ {
-		for y := 0; y < bounds.Max.Y; y++ {
-			checkedColor := img.At(x, y)
-			if match, firstType, secondType := checkColorMatch(
-				difference, currentColor, checkedColor, dict); match {
-				firstLocation := getPixelNumber(
-					location.x, location.y, bounds.Max.X)
-				secondLocation := getPixelNumber(x, y, bounds.Max.X)
-				return []byte(fmt.Sprintf(
-					"%s%v%s%v",
-					string(firstType), firstLocation,
-					string(secondType), secondLocation)), nil
-			}
-		}
+	bounds := key.Bounds()
+	if match, firstType, secondType := checkColorMatch(
+		difference, currentColor, checkedColor, dict); match {
+		firstLocation := getPixelNumber(
+			currentLocation.x, currentLocation.y, bounds.Max.X)
+		secondLocation := getPixelNumber(
+			checkedLocation.x, checkedLocation.y, bounds.Max.X)
+		return []byte(fmt.Sprintf(
+			"%s%v%s%v",
+			string(firstType), firstLocation,
+			string(secondType), secondLocation)), nil
 	}
+
 	return nil, errorMatchNotFound
 }
 

--- a/encoder_image_test.go
+++ b/encoder_image_test.go
@@ -145,3 +145,42 @@ func TestEncodeImageConcurrentPartial(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestImageImagePPM(t *testing.T) {
+	file, err := os.Open("images/body.bin")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	key, err := LoadImage("images/test.png")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	reader, err := EncodeImageStream(file, key)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	key2, err := LoadImage("images/image.jpg")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	decoded, err := DecodeImageStream(reader, key2)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	data, err := ioutil.ReadAll(decoded)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	err = ioutil.WriteFile("images/body.ecb.bin", data, 0644)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+}

--- a/encoder_image_test.go
+++ b/encoder_image_test.go
@@ -2,6 +2,7 @@ package decouplet
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -104,7 +105,7 @@ func TestEncodeImageConcurrent(t *testing.T) {
 	}
 	msg := []byte("Test this message and see it stream")
 	input := bytes.NewReader(msg)
-	reader := EncodeImageStream(input, image)
+	reader, err := EncodeImageStream(input, image)
 	if err != nil {
 		t.Error(err)
 	}
@@ -129,7 +130,10 @@ func TestEncodeImageConcurrentPartial(t *testing.T) {
 	skip := 3
 	msg := []byte("Test this message and see it stream, using partial encoding.")
 	input := bytes.NewReader(msg)
-	reader := EncodeImageStreamPartial(input, image, take, skip)
+	reader, err := EncodeImageStreamPartial(input, image, take, skip)
+	if err != nil {
+		fmt.Println(err)
+	}
 	newReader, err := DecodeImageStreamPartial(reader, image)
 	if err != nil {
 		t.Error(err)

--- a/models.go
+++ b/models.go
@@ -6,6 +6,7 @@ import (
 
 var errorMatchNotFound = errors.New("match not found")
 var errorDecodeNotFound = errors.New("valid decode character not found")
+var errorKeyCastFailed = errors.New("failed to cast key")
 
 const partialStart string = ";[&"
 const partialEnd string = "&];"


### PR DESCRIPTION
Implemented fixes from running the ECB Penguin(https://blog.filippo.io/the-ecb-penguin/)

The issue was with the way initialization of match searches were happening. It was far too predictable and was a straight line which allowed it to be far too predictable, especially in the case of the first characters. This will help this by doing two things:
- Randomizing both starting positions at the same time(initial and checked)
- Iterating in a different order depending on those positions(+ or -)

This is the initial of a few more fixes that will be made to hopefully make this more secure. The goal is to implement several other patterns that will help make this better.
