### PR TITLE
Naming and scope changes, and added variance checking

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -12,16 +12,16 @@ func decode(
 	groups int,
 	decodeFunc func(encodingKey, decodeGroup) (byte, error),
 ) (output []byte, err error) {
-	if valid, err := key.CheckValid(); !valid {
+	if valid, err := key.checkValid(); !valid {
 		return nil, err
 	}
 
-	err = key.GetVersion().CheckEncoder(&input)
+	err = key.getVersion().checkEncoder(&input)
 	if err != nil {
 		return nil, err
 	}
 	decodeGroups, err := findDecodeGroups(
-		input, key.GetDictionaryChars(), groups)
+		input, key.getDictionarySet(), groups)
 	if err != nil {
 		return nil, err
 	}
@@ -35,14 +35,14 @@ func decodeStream(
 	groups int,
 	decodeFunc func(encodingKey, decodeGroup) (byte, error),
 ) (output *io.PipeReader, err error) {
-	if valid, err := key.CheckValid(); !valid {
+	if valid, err := key.checkValid(); !valid {
 		return nil, err
 	}
 
 	reader, writer := io.Pipe()
 
 	go func() {
-		chars := key.GetDictionaryChars()
+		chars := key.getDictionarySet()
 		defer writer.Close()
 
 		charSplit := splitInfo{chars: chars, groups: groups}
@@ -89,7 +89,7 @@ func decodePartialStream(
 	groups int,
 	decodeFunc func(encodingKey, decodeGroup) (byte, error),
 ) (output *io.PipeReader, err error) {
-	if valid, err := key.CheckValid(); !valid {
+	if valid, err := key.checkValid(); !valid {
 		return nil, err
 	}
 
@@ -152,7 +152,7 @@ func writeDecodeBuffer(
 	key encodingKey,
 	writer io.Writer,
 ) error {
-	decodeGroups, err := findDecodeGroups(buffer, key.GetDictionaryChars(), groups)
+	decodeGroups, err := findDecodeGroups(buffer, key.getDictionarySet(), groups)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func writeDecodeBuffer(
 
 func findDecodeGroups(
 	input []byte,
-	characters dictionaryChars,
+	characters dictionarySet,
 	numGroups int,
 ) (decodeGroups []decodeGroup, err error) {
 	if !characters.checkIn(input[0]) {

--- a/encoder.go
+++ b/encoder.go
@@ -8,10 +8,10 @@ import (
 )
 
 type encodingKey interface {
-	GetVersion() EncoderInfo
-	CheckValid() (bool, error)
-	GetDictionaryChars() dictionaryChars
-	GetDictionary() dictionary
+	getVersion() encoderInfo
+	checkValid() (bool, error)
+	getDictionarySet() dictionarySet
+	getDictionary() dictionary
 }
 
 func encode(
@@ -19,11 +19,11 @@ func encode(
 	key encodingKey,
 	encoder func(byte, encodingKey) ([]byte, error),
 ) ([]byte, error) {
-	if valid, err := key.CheckValid(); !valid {
+	if valid, err := key.checkValid(); !valid {
 		return nil, err
 	}
 
-	b, err := key.GetVersion().WriteVersion()
+	b, err := key.getVersion().writeVersion()
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func encodeStream(
 	key encodingKey,
 	encoder func(byte, encodingKey) ([]byte, error),
 ) (*io.PipeReader, error) {
-	if valid, err := key.CheckValid(); !valid {
+	if valid, err := key.checkValid(); !valid {
 		return nil, err
 	}
 	reader, writer := io.Pipe()
@@ -92,7 +92,7 @@ func encodePartialStream(
 	encoder func(byte, encodingKey) ([]byte, error),
 ) (*io.PipeReader, error) {
 	reader, writer := io.Pipe()
-	if valid, err := key.CheckValid(); !valid {
+	if valid, err := key.checkValid(); !valid {
 		return nil, err
 	}
 

--- a/encoder.go
+++ b/encoder.go
@@ -12,6 +12,7 @@ type encodingKey interface {
 	checkValid() (bool, error)
 	getDictionarySet() dictionarySet
 	getDictionary() dictionary
+	checkVariance() int
 }
 
 func encode(

--- a/encoder_byte.go
+++ b/encoder_byte.go
@@ -22,6 +22,7 @@ type bytesKey []byte
 
 const matchFindRetriesByte = 16
 const minByteKeySize = 64
+const byteCheckedMax = 255
 
 var errorByteKeyTooShort = errors.New("key is smaller than minimum length of 64 bytes")
 
@@ -37,6 +38,14 @@ func (k bytesKey) checkValid() (bool, error) {
 		return false, errorByteKeyTooShort
 	}
 	return true, nil
+}
+
+func (k bytesKey) checkVariance() int {
+	charMap := map[byte]bool{}
+	for _, b := range k {
+		charMap[b] = true
+	}
+	return int((float32(len(charMap)) / byteCheckedMax) * 100)
 }
 
 func (bytesKey) getDictionarySet() dictionarySet {

--- a/encoder_byte_test.go
+++ b/encoder_byte_test.go
@@ -10,27 +10,29 @@ import (
 )
 
 func TestEncodeBytes(t *testing.T) {
-	newMessage, err := EncodeBytes([]byte("Test"), []byte("tEst Key3#$T234Alklgn"))
+	key := make([]byte, 256)
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	newMessage, err := EncodeBytes([]byte("Test"), key)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log(string(newMessage))
 }
 
-func TestDecoderBytes(t *testing.T) {
-	message, err := DecodeBytes(
-		[]byte("[dcplt-byteec-0.2]e12i16d17k11k17g11k12e4"), []byte("tEst Key3#$"))
+func TestByteMessage(t *testing.T) {
+	key := make([]byte, 256)
+	_, err := rand.Read(key)
 	if err != nil {
 		t.Error(err)
+		t.FailNow()
 	}
-	t.Log(string(message))
-}
-
-func TestByteMessage(t *testing.T) {
 	originalMessage :=
 		"!!**_-+Test THIS bigger message with More Symbols" +
 			"@$_()#$%^#@!~#2364###$%! *(#$%)^@#%$@"
-	key := []byte("Test encodingKey!@# $Aaaaaallgglglmefmogaloehkogpeloskoge ekgogjwogkl 2346923052306235023060923503289362305028602395026023950260235028602597235923")
 	newMessage, err := EncodeBytes(
 		[]byte(originalMessage), key)
 	if err != nil {
@@ -48,6 +50,12 @@ func TestByteMessage(t *testing.T) {
 }
 
 func TestByteMessage_Byte(t *testing.T) {
+	key := make([]byte, 256)
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
 	imageFile, err := os.Open("images/test.jpg")
 	if err != nil {
 		t.Error(err)
@@ -62,11 +70,6 @@ func TestByteMessage_Byte(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	key := []byte(
-		"$#%#%@#$@$)*^_#@$*^)@$)@#" +
-			"^@#%@#)^Test byte encodingKey!@#$" +
-			"^GEWg gwefwgwef _#$%@#$%L",
-	)
 	t.Log("Length of original:", len(fileBytes))
 	newMessage, err := EncodeBytes(fileBytes, key)
 	if err != nil {
@@ -89,7 +92,12 @@ func TestByteMessage_Byte(t *testing.T) {
 }
 
 func TestEncodeBytesConcurrent(t *testing.T) {
-	key := []byte("tEst Key3#$!@&*()[]:;")
+	key := make([]byte, 256)
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
 	msg := []byte("Test this message and see it stream")
 	input := bytes.NewReader(msg)
 	reader, err := EncodeBytesStream(input, key)
@@ -109,7 +117,12 @@ func TestEncodeBytesConcurrent(t *testing.T) {
 }
 
 func TestEncodeBytesConcurrentPartial(t *testing.T) {
-	key := []byte("tEst Key3#$!@&*()[]:;")
+	key := make([]byte, 256)
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
 	msg := []byte("Test this message and see it stream and be partially encoded! here")
 	take := 1
 	skip := 3
@@ -129,32 +142,6 @@ func TestEncodeBytesConcurrentPartial(t *testing.T) {
 		t.Log("bytes are not equal")
 		t.Fail()
 	}
-}
-
-func TestAnalyzeBytesKey(t *testing.T) {
-	badKey := []byte("badkey")
-	scale := AnalyzeBytesKey(badKey)
-	t.Log("bad key analysis:", scale)
-	if scale > 10 {
-		t.Log("small, insufficient keys usually register under 10")
-		t.Fail()
-	}
-	goodKey := []byte("This is a Key$%@#$@^^%$&$%%^*{})([p[]Should _-!`~")
-	scale = AnalyzeBytesKey(goodKey)
-	t.Log("good key analysis:", scale)
-	if scale < 10 {
-		t.Log("good keys should be 10 or over")
-		t.Fail()
-	}
-	greatKey := []byte(
-		"GREAFgolanVMb elefwoejgitoiqwaz12353445789870-0=)" +
-			"(_#@$^#$&$%&$*$&$0238959_=2340+=12!@#$%^&*(()")
-	scale = AnalyzeBytesKey(greatKey)
-	if scale < 20 {
-		t.Log("great keys should be 20 or over(not really a hard number)")
-		t.Fail()
-	}
-	t.Log("great key analysis:", scale)
 }
 
 // Examples
@@ -245,6 +232,9 @@ func ExampleDecodeBytesStreamPartial() {
 }
 
 func TestImageBytePPM(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	file, err := os.Open("images/body.bin")
 	if err != nil {
 		t.Error(err)

--- a/encoder_image.go
+++ b/encoder_image.go
@@ -21,6 +21,7 @@ type imageKey struct {
 
 const matchFindRetriesImage = 4
 const imageKeySize = 300
+const imageCheckedMax = 46368
 
 var errorImageKeyTooSmall = errors.New("key needs to be larger than 300x300")
 
@@ -29,6 +30,16 @@ func (imageKey) getVersion() encoderInfo {
 		Name:    "imgec",
 		Version: "0.2",
 	}
+}
+
+func (k imageKey) checkVariance() int {
+	colorMap := map[color.Color]bool{}
+	for x := 0; x < k.Image.Bounds().Max.X; x++ {
+		for y := 0; y < k.Image.Bounds().Max.Y; y++ {
+			colorMap[k.At(x, y)] = true
+		}
+	}
+	return int((float32(len(colorMap)) / imageCheckedMax) * 100)
 }
 
 func (k imageKey) checkValid() (bool, error) {

--- a/encoder_image.go
+++ b/encoder_image.go
@@ -24,25 +24,25 @@ const imageKeySize = 300
 
 var errorImageKeyTooSmall = errors.New("key needs to be larger than 300x300")
 
-func (imageKey) GetVersion() EncoderInfo {
-	return EncoderInfo{
+func (imageKey) getVersion() encoderInfo {
+	return encoderInfo{
 		Name:    "imgec",
 		Version: "0.2",
 	}
 }
 
-func (k imageKey) CheckValid() (bool, error) {
+func (k imageKey) checkValid() (bool, error) {
 	if k.Image.Bounds().Max.X < imageKeySize || k.Image.Bounds().Max.Y < imageKeySize {
 		return false, errorImageKeyTooSmall
 	}
 	return true, nil
 }
 
-func (imageKey) GetDictionaryChars() dictionaryChars {
-	return dictionaryChars("rgbacmyk")
+func (imageKey) getDictionarySet() dictionarySet {
+	return dictionarySet("rgbacmyk")
 }
 
-func (imageKey) GetDictionary() dictionary {
+func (imageKey) getDictionary() dictionary {
 	return dictionary{
 		decoders: []decodeRef{
 			{
@@ -153,7 +153,7 @@ func getImgDefs(key encodingKey, group decodeGroup) (byte, error) {
 	if !ok {
 		return 0, errors.New("failed to cast key")
 	}
-	dict := key.GetDictionary()
+	dict := key.getDictionary()
 
 	loc1, err := strconv.Atoi(group.place[0])
 	if err != nil {
@@ -216,7 +216,7 @@ func getPixelPattern(char byte, key imageKey) ([]byte, error) {
 	currentY := rand.Intn(bounds.Max.Y)
 	startX := rand.Intn(bounds.Max.X)
 	startY := rand.Intn(bounds.Max.Y)
-	dictionary := key.GetDictionary()
+	dictionary := key.getDictionary()
 
 	pattern := make([]byte, 0)
 	var err error

--- a/encoder_image_test.go
+++ b/encoder_image_test.go
@@ -147,6 +147,9 @@ func TestEncodeImageConcurrentPartial(t *testing.T) {
 }
 
 func TestImageImagePPM(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	file, err := os.Open("images/body.bin")
 	if err != nil {
 		t.Error(err)

--- a/metadata.go
+++ b/metadata.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 )
 
-type EncoderInfo struct {
+type encoderInfo struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 }
 
-var EncodersList []EncoderInfo
-
-func (i EncoderInfo) GetEncoderString() (string, error) {
+func (i encoderInfo) getEncoderString() (string, error) {
 	return fmt.Sprintf(
 		"[dcplt-%s-%s]",
 		i.Name,
@@ -21,8 +19,8 @@ func (i EncoderInfo) GetEncoderString() (string, error) {
 	), nil
 }
 
-func (i EncoderInfo) CheckEncoder(message *[]byte) error {
-	meta, err := i.GetEncoderString()
+func (i encoderInfo) checkEncoder(message *[]byte) error {
+	meta, err := i.getEncoderString()
 	if err != nil {
 		return err
 	}
@@ -34,8 +32,8 @@ func (i EncoderInfo) CheckEncoder(message *[]byte) error {
 	return errors.New("encoder version does not match")
 }
 
-func (i EncoderInfo) WriteVersion() ([]byte, error) {
-	meta, err := i.GetEncoderString()
+func (i encoderInfo) writeVersion() ([]byte, error) {
+	meta, err := i.getEncoderString()
 	if err != nil {
 		return nil, err
 	}

--- a/models.go
+++ b/models.go
@@ -7,6 +7,8 @@ import (
 var errorMatchNotFound = errors.New("match not found")
 var errorDecodeNotFound = errors.New("valid decode character not found")
 var errorKeyCastFailed = errors.New("failed to cast key")
+var errorDecodeGeneric = errors.New("decode error")
+var errorDecodeGroup = errors.New("decode groups missing locations")
 
 const partialStart string = ";[&"
 const partialEnd string = "&];"
@@ -14,13 +16,7 @@ const partialEnd string = "&];"
 var partialStartBytes = []byte(partialStart)
 var partialEndBytes = []byte(partialEnd)
 
-type encoderType string
-
-type dictionaryChars string
-
-type byteGroup struct {
-	bytes []byte
-}
+type dictionarySet string
 
 type decodeGroup struct {
 	kind  []uint8
@@ -37,7 +33,7 @@ type decodeRef struct {
 }
 
 type splitInfo struct {
-	chars  dictionaryChars
+	chars  dictionarySet
 	groups int
 }
 
@@ -46,7 +42,7 @@ type location struct {
 	y int
 }
 
-func (chars dictionaryChars) checkIn(a byte) bool {
+func (chars dictionarySet) checkIn(a byte) bool {
 	for i := range chars {
 		if a == chars[i] {
 			return true


### PR DESCRIPTION
Added new checkVariance to encoder types, to check theoretically how useful a key is by a percentage. 

- Byte encoder is accurate since it's at a normal byte scope(255).
- Image encoder is a little less true, and shows nothing of the true number of colors allowed by an image, since most images won't use even close to the full scope of colors allowed. Instead, it gives an idea of how many colors you're using and may be at a percentage greater than 100 if you used a sufficiently large number of colors.